### PR TITLE
Merge new README.md file, and patch for Double Dragon 2 Dip Switch settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+What does the Recording Version do?
+===================================
+
+FinalBurn Alpha Rerecording is the rerecording version of [Final Burn Alpha]
+with many customized features designed to aid in recording movie input files
+
+Resources
+=========
+
+http://tasvideos.org/forum/viewtopic.php?t=7234
+http://tasvideos.org/EmulatorResources/Fbarr.html
+http://tasvideos.org/EmulatorResources/Fbarr/FBM.html
+
+
+Windows Compilation Guide for Dummies
+=====================================
+
+For people like myself who aren't familiar with compiling code in Windows, this is easiest way to get yourself building FBA-rr.
+
+Follow the FBA [Compilation Guide] for GCC 3.4.5. *BUT*, before running `mingw32-make mingw345`, you'll have to take care of LUA dependencies
+
+
+- In `c:\mingw345\makefile.mingw345`, comment out this line
+
+  ```
+  allobj += $(srcdir)depend/libs/lua/liblua51.a
+  ```
+
+- Copy Lua Headers into place
+  1. Download [Lua 5.1.5 source code]
+  2. Copy `src\*.h` into `c:\mingw345\include`
+
+- Copy Lua Binaries into place
+  1. Download latest build of [Lua 5.1.5 Libraries] files from Sourceforge
+  1. Copy `lua5.1.dll` and `lua5.1.lib` into `c:\mingw345\lib`  
+
+[Compilation Guide]: https://www.fbalpha.com/compile/
+[Lua 5.1.5 source code]: https://www.lua.org/versions.html#5.1
+[Lua 5.1.5 Libraries]: https://sourceforge.net/projects/luabinaries/files/5.1.5/Windows%20Libraries/Dynamic/
+[Final Burn Alpha]: https://www.fbalpha.com/

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ with many customized features designed to aid in recording movie input files
 Resources
 =========
 
-http://tasvideos.org/forum/viewtopic.php?t=7234
-http://tasvideos.org/EmulatorResources/Fbarr.html
-http://tasvideos.org/EmulatorResources/Fbarr/FBM.html
+- http://tasvideos.org/forum/viewtopic.php?t=7234
+- http://tasvideos.org/EmulatorResources/Fbarr.html
+- http://tasvideos.org/EmulatorResources/Fbarr/FBM.html
 
 
 Windows Compilation Guide for Dummies

--- a/fbarr/src/burn/drivers/misc_pre90s/d_ddragon.cpp
+++ b/fbarr/src/burn/drivers/misc_pre90s/d_ddragon.cpp
@@ -214,6 +214,22 @@ static struct BurnDIPInfo Drv2DIPList[]=
 	{0x14, 0x01, 0x80, 0x00, "On"                     },
 	
 	// Dip 2
+	// Note the difficulty settings were pulled from MAME
+	// Do not use the real Double Dragon 2 Manual as
+	// reference, because it lists wrong settings!
+	//
+	// If anyone points you to bad settings from Manual
+	//  they will look like this:
+	//   OFF OFF = Normal
+	//   OFF OFF = Easy
+	//   ON  OFF = Less Than Difficult
+	//   ON  ON  = Difficult
+	{0   , 0xfe, 0   , 4   , "Difficulty"             },
+	{0x15, 0x01, 0x03, 0x01, "Easy"                   },
+	{0x15, 0x01, 0x03, 0x03, "Medium"                 },
+	{0x15, 0x01, 0x03, 0x02, "Hard"                   },
+	{0x15, 0x01, 0x03, 0x00, "Hardest"                },
+
 	{0   , 0xfe, 0   , 2   , "Hurricane Kick"         },
 	{0x15, 0x01, 0x08, 0x00, "Easy"                   },
 	{0x15, 0x01, 0x08, 0x08, "Normal"                 },


### PR DESCRIPTION
This PR takes care of adding a README to base of repo, as well as a patch for Double Dragon 2's Dip Switch Settings - The "Difficulty" settings were missing for this game.